### PR TITLE
Patched path errors in Windows

### DIFF
--- a/src/core/generateIndexFile.js
+++ b/src/core/generateIndexFile.js
@@ -7,7 +7,7 @@ module.exports = files => {
 
   for (let index = 0; index < files.length; index++) {
     const file = files[index]
-    const filePath = file.path.replace('.gd', '.md')
+    const filePath = file.path.replace('.gd', '.md').replace(path.sep, '/')
     const fileName = file.name
 
     outputString += `- [${fileName}](./${filePath})\n`

--- a/src/core/parsers/parseFile.js
+++ b/src/core/parsers/parseFile.js
@@ -156,7 +156,7 @@ module.exports = filePath => {
       file = {
         name: null,
         description: null,
-        path: `${filePath.replace(config.projectDir + '/', '')}`,
+        path: `${filePath.replace(config.projectDir + path.sep, '')}`,
         icon: null,
         tool: false,
         extends: null,


### PR DESCRIPTION
There was a hardcoded `"/"` used as path separator. Replaced by `path.sep`.

I can generate docs in Windows now. 😄 